### PR TITLE
Use WindowSize API instead of window.size.

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -223,7 +223,7 @@ namespace Tizen.NUI
                 else
                 {
                     // Parent not a View so assume it's a Layer which is the size of the window.
-                    rootSize = new Size2D(_window.Size.Width, _window.Size.Height);
+                    rootSize = _window.WindowSize;
                 }
 
                 // Determine measure specification for root.


### PR DESCRIPTION
Change-Id: Ia6e04c5f7504f7fdc78b5a533e51a4ab448deae9

### Description of Change ###
Using the NUI WindowSize API instead of window.Size.width and window.Size.Height.
WindowSize is the API to set and get window size.
