### PR TITLE
[NUI] Enable cascade-property-set for Size, Position

### DIFF
--- a/src/Tizen.NUI/src/public/BaseComponents/View.cs
+++ b/src/Tizen.NUI/src/public/BaseComponents/View.cs
@@ -2506,7 +2506,8 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Position)GetValue(ParentOriginProperty);
+                Position tmp = (Position)GetValue(ParentOriginProperty);
+                return new Position(OnParentOriginChanged, tmp.X, tmp.Y, tmp.Z);
             }
             set
             {
@@ -2528,7 +2529,8 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Position)GetValue(PivotPointProperty);
+                Position tmp = (Position)GetValue(PivotPointProperty);
+                return new Position(OnPivotPointChanged, tmp.X, tmp.Y, tmp.Z);
             }
             set
             {
@@ -2583,7 +2585,8 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Position)GetValue(PositionProperty);
+                Position tmp = (Position)GetValue(PositionProperty);
+                return new Position(OnPositionChanged, tmp.X, tmp.Y, tmp.Z);
             }
             set
             {
@@ -3135,7 +3138,8 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Size2D)GetValue(MinimumSizeProperty);
+                Size2D tmp = (Size2D)GetValue(MinimumSizeProperty);
+                return new Size2D(OnMinimumSizeChanged, tmp.Width, tmp.Height);
             }
             set
             {
@@ -3160,7 +3164,8 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Size2D)GetValue(MaximumSizeProperty);
+                Size2D tmp = (Size2D)GetValue(MaximumSizeProperty);
+                return new Size2D(OnMaximumSizeChanged, tmp.Width, tmp.Height);
             }
             set
             {
@@ -3272,7 +3277,8 @@ namespace Tizen.NUI.BaseComponents
         {
             get
             {
-                return (Size)GetValue(SizeProperty);
+                Size tmp = (Size)GetValue(SizeProperty);
+                return new Size(OnSizeChanged, tmp.Width, tmp.Height, tmp.Depth);
             }
             set
             {
@@ -5324,9 +5330,39 @@ namespace Tizen.NUI.BaseComponents
             Size2D = new Size2D(width, height);
         }
 
+        private void OnMinimumSizeChanged(int width, int height)
+        {
+            MinimumSize = new Size2D(width, height);
+        }
+
+        private void OnMaximumSizeChanged(int width, int height)
+        {
+            MaximumSize = new Size2D(width, height);
+        }
+
         private void OnPosition2DChanged(int x, int y)
         {
             Position2D = new Position2D(x, y);
+        }
+
+        private void OnSizeChanged(float width, float height, float depth)
+        {
+            Size = new Size(width, height, depth);
+        }
+
+        private void OnPositionChanged(float x, float y, float z)
+        {
+            Position = new Position(x, y, z);
+        }
+
+        private void OnParentOriginChanged(float x, float y, float z)
+        {
+            ParentOrigin = new Position(x, y, z);
+        }
+
+        private void OnPivotPointChanged(float x, float y, float z)
+        {
+            PivotPoint = new Position(x, y, z);
         }
 
         private void DisConnectFromSignals()

--- a/src/Tizen.NUI/src/public/Position.cs
+++ b/src/Tizen.NUI/src/public/Position.cs
@@ -545,6 +545,8 @@ namespace Tizen.NUI
             {
                 Interop.Vector3.Vector3_X_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+                callback?.Invoke(X, Y, Z);
             }
             get
             {
@@ -564,6 +566,8 @@ namespace Tizen.NUI
             {
                 Interop.Vector3.Vector3_Y_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+                callback?.Invoke(X, Y, Z);
             }
             get
             {
@@ -583,6 +587,8 @@ namespace Tizen.NUI
             {
                 Interop.Vector3.Vector3_Z_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+                callback?.Invoke(X, Y, Z);
             }
             get
             {
@@ -952,5 +958,14 @@ namespace Tizen.NUI
             return ret;
         }
 
+        internal delegate void PositionChangedCallback(float x, float y, float z);
+
+        internal Position(PositionChangedCallback cb, float x, float y, float z) : this(Interop.Vector3.new_Vector3__SWIG_1(x, y, z), true)
+        {
+            callback = cb;
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        private PositionChangedCallback callback = null;
     }
 }

--- a/src/Tizen.NUI/src/public/Size.cs
+++ b/src/Tizen.NUI/src/public/Size.cs
@@ -111,6 +111,8 @@ namespace Tizen.NUI
             {
                 Interop.Vector3.Vector3_Width_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+                callback?.Invoke(Width, Height, Depth);
             }
             get
             {
@@ -130,6 +132,8 @@ namespace Tizen.NUI
             {
                 Interop.Vector3.Vector3_Height_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+                callback?.Invoke(Width, Height, Depth);
             }
             get
             {
@@ -149,6 +153,8 @@ namespace Tizen.NUI
             {
                 Interop.Vector3.Vector3_Depth_set(swigCPtr, value);
                 if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+
+                callback?.Invoke(Width, Height, Depth);
             }
             get
             {
@@ -463,6 +469,16 @@ namespace Tizen.NUI
             if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
             return ret;
         }
+
+        internal delegate void SizeChangedCallback(float width, float height, float depth);
+
+        internal Size(SizeChangedCallback cb, float w, float h, float d) : this(Interop.Vector3.new_Vector3__SWIG_1(w, h, d), true)
+        {
+            callback = cb;
+            if (NDalicPINVOKE.SWIGPendingException.Pending) throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+        }
+
+        private SizeChangedCallback callback = null;
     }
 }
 


### PR DESCRIPTION
### Description of Change ###
[NUI] Enable cascade-property-set for Size, Position

- in View.cs
  public Size2D Size2D : done
  public Size2D CurrentSize : only get, no need to fix
  public Size2D CurrentSize : only get, no need to fix
  public Size2D NaturalSize2D : only get, no need to fix
  public Size2D MinimumSize : done
  public Size2D MaximumSize : done
  public Position2D Position2D : done
  public Size Size : done
  public Position ParentOrigin : done
  public Position PivotPoint : done
  public Position Position : done
  public Position AnchorPoint : obsoleted, no need to fix
  public Position CurrentPosition : only get, no need to fix

Signed-off-by: dongsug.song <dongsug.song@samsung.com>

### API Changes ###
None