### PR TITLE
Add property LayoutWithTransition to LayoutItem

### DIFF
--- a/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
+++ b/src/Tizen.NUI/src/internal/Layouting/LayoutController.cs
@@ -525,8 +525,8 @@ namespace Tizen.NUI
             }
 
             // Set up a default transitions, will be overwritten if inherited from parent or set explicitly.
-            TransitionComponents positionTransitionComponents = CreateDefaultTransitionComponent(0, 0);
-            TransitionComponents sizeTransitionComponents = CreateDefaultTransitionComponent(0, 0);
+            TransitionComponents positionTransitionComponents = CreateDefaultTransitionComponent(0, 300);
+            TransitionComponents sizeTransitionComponents = CreateDefaultTransitionComponent(0, 300);
 
             bool matchedCustomTransitions = false;
 

--- a/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutGroup.cs
@@ -88,15 +88,27 @@ namespace Tizen.NUI
             {
                 if( childLayout == layoutItem )
                 {
-                    if (! childLayout.IsReplaceFlag())
-                    {
-                        Window.Instance.LayoutController.AddToRemovalStack(childLayout);
-                    }
                     childLayout.ClearReplaceFlag();
                     LayoutChildren.Remove(childLayout);
-                    childLayout.ConditionForAnimation = childLayout.ConditionForAnimation | TransitionCondition.Remove;
-                    // Add LayoutItem to the transition stack so can animate it out.
-                    Window.Instance.LayoutController.AddTransitionDataEntry(new LayoutData(layoutItem, ConditionForAnimation, 0,0,0,0));
+
+                    if (LayoutWithTransition)
+                    {
+                        if (!childLayout.IsReplaceFlag())
+                        {
+                            Window.Instance.LayoutController.AddToRemovalStack(childLayout);
+                        }
+
+                        childLayout.ConditionForAnimation = childLayout.ConditionForAnimation | TransitionCondition.Remove;
+                        // Add LayoutItem to the transition stack so can animate it out.
+                        Window.Instance.LayoutController.AddTransitionDataEntry(new LayoutData(layoutItem, ConditionForAnimation, 0, 0, 0, 0));
+                    }
+                    else
+                    {
+                        Interop.Actor.Actor_Remove(View.getCPtr(childLayout.Owner.Parent), View.getCPtr(childLayout.Owner));
+                        if (NDalicPINVOKE.SWIGPendingException.Pending)
+                            throw NDalicPINVOKE.SWIGPendingException.Retrieve();
+                    }
+
                     // Reset condition for animation ready for next transition when required.
                     // SetFrame usually would do this but this LayoutItem is being removed.
                     childLayout.ConditionForAnimation = TransitionCondition.Unspecified;

--- a/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
+++ b/src/Tizen.NUI/src/public/Layouting/LayoutItem.cs
@@ -65,6 +65,12 @@ namespace Tizen.NUI
         public View Owner{get; set;}  // Should not keep a View alive.
 
         /// <summary>
+        /// [Draft] Use transition for layouting child
+        /// </summary>
+        /// <since_tizen> 6 </since_tizen>
+        public bool LayoutWithTransition{get; set;}
+
+        /// <summary>
         /// [Draft] Margin for this LayoutItem
         /// </summary>
         /// <since_tizen> 6 </since_tizen>
@@ -136,6 +142,7 @@ namespace Tizen.NUI
 
         private void Initialize()
         {
+            LayoutWithTransition = true;
             _layoutPositionData = new LayoutData(this,TransitionCondition.Unspecified,0,0,0,0);
             _padding = new Extents(0,0,0,0);
             _margin = new Extents(0,0,0,0);
@@ -518,7 +525,16 @@ namespace Tizen.NUI
                                                          " right:" + _layoutPositionData.Right +
                                                          " bottom:" + _layoutPositionData.Bottom );
 
-                Window.Instance.LayoutController.AddTransitionDataEntry(_layoutPositionData);
+                if (Owner.Parent != null && Owner.Parent.Layout != null && Owner.Parent.Layout.LayoutWithTransition)
+                {
+                    Window.Instance.LayoutController.AddTransitionDataEntry(_layoutPositionData);
+                }
+                else
+                {
+                    Owner.Size = new Size(right - left, bottom - top, Owner.Position.Z);
+                    Owner.Position = new Position(left, top, Owner.Position.Z);
+                }
+
 
                 // Reset condition for animation ready for next transition when required.
                 ConditionForAnimation = TransitionCondition.Unspecified;


### PR DESCRIPTION
Not every developer wants default transition effect in Layout.

For them, make property which can enable or disable transition effect.
Currently, default is false but can be changed.

This property only effects to chilren of Layout Owner.

### Description of Change ###
<!-- Describe your changes here. -->


### API Changes ###
<!-- If you have the ACR for changing APIs, put the link of the ACR: -->
 - ACR:

<!--
If you can't make the ACR, List all API changes here (or just put None), example:
Added:
 - SafeBundleHandle Bundle.SafeBundleHandle { get; } // Property
 - void Bundle.AddItem(string key, string value);

Changed:
 - object Bundle.ReceiveItem(string key) => object Bundle.GetItem(string key);
-->
