### PR TITLE
Use a platform agnostic name for native libraries

### DIFF
--- a/src/Tizen.Applications.Common/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.Common/Interop/Interop.Libraries.cs
@@ -18,10 +18,10 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string AppCommon = "libcapi-appfw-app-common.so.0";
+        public const string AppCommon = "capi-appfw-app-common";
         public const string AppControl = "libcapi-appfw-app-control.so.0";
         public const string AppEvent = "libcapi-appfw-event.so.0";
-        public const string AppManager = "libcapi-appfw-app-manager.so.0";
+        public const string AppManager = "capi-appfw-app-manager";
         public const string Bundle = "libbundle.so.0";
         public const string Rua = "librua.so.0";
         public const string Glib = "libglib-2.0.so.0";

--- a/src/Tizen.Applications.WatchApplication/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.WatchApplication/Interop/Interop.Libraries.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string AppCommon = "libcapi-appfw-app-common.so.0";
+        public const string AppCommon = "capi-appfw-app-common";
         public const string AppCoreWatch = "libappcore-watch.so.1";
     }
 }

--- a/src/Tizen.Applications.WidgetApplication/Interop/Interop.Libraries.cs
+++ b/src/Tizen.Applications.WidgetApplication/Interop/Interop.Libraries.cs
@@ -18,7 +18,7 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string AppCommon = "libcapi-appfw-app-common.so.0";
+        public const string AppCommon = "capi-appfw-app-common";
         public const string AppcoreWidget = "libcapi-appfw-widget-application.so.1";
         public const string WidgetService = "libwidget_service.so.1";
     }

--- a/src/Tizen.Log/Interop/Interop.Dlog.cs
+++ b/src/Tizen.Log/Interop/Interop.Dlog.cs
@@ -20,7 +20,7 @@ internal static partial class Interop
 {
     internal static partial class Libraries
     {
-        public const string Dlog = "libdlog.so.0";
+        public const string Dlog = "dlog";
     }
 
     internal static partial class Dlog

--- a/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
+++ b/src/Tizen.NUI/src/internal/Interop/NDalicPINVOKE.cs
@@ -20,7 +20,7 @@ namespace Tizen.NUI
 
     class NDalicPINVOKE
     {
-        public const string Lib = "libdali2-csharp-binder.so";
+        public const string Lib = "dali2-csharp-binder";
         protected class SWIGExceptionHelper
 		{
 			/// <since_tizen> 3 </since_tizen>


### PR DESCRIPTION
This patch makes the DALi C# binder and tizenfx-stub library names
platform agnostic. This guarantees they can be loaded in Windows and
Linux environments.